### PR TITLE
[codex] Restore build validation

### DIFF
--- a/components/starfield/camera-focus.tsx
+++ b/components/starfield/camera-focus.tsx
@@ -1,13 +1,16 @@
 'use client';
 
 import { useFrame, useThree } from '@react-three/fiber';
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import * as THREE from 'three';
+
+import type { RefObject } from 'react';
+import type { OrbitControls as OrbitControlsImpl } from 'three-stdlib';
 
 export type CameraPhase = 'idle' | 'focusing' | 'restoring';
 
 export type CameraFocusProps = {
-  controlsRef: React.RefObject<any>;
+  controlsRef: RefObject<OrbitControlsImpl | null>;
   target: THREE.Vector3 | null;
   active: boolean;
   zoomFactor?: number;
@@ -41,12 +44,12 @@ export default function CameraFocus({
   // 记录最近一次用于聚焦的目标位置（用于检测目标切换）
   const lastFocusTarget = useRef(new THREE.Vector3(NaN, NaN, NaN));
 
-  const setPhase = (p: CameraPhase) => {
+  const setPhase = useCallback((p: CameraPhase) => {
     if (mode.current !== p) {
       mode.current = p;
       onPhaseChange?.(p);
     }
-  };
+  }, [onPhaseChange]);
 
   // 聚焦动画进行中如用户开始拖拽，则取消动画（交出控制）
   useEffect(() => {
@@ -57,7 +60,7 @@ export default function CameraFocus({
     };
     controls.addEventListener?.('start', onStart);
     return () => controls.removeEventListener?.('start', onStart);
-  }, [controlsRef]);
+  }, [controlsRef, setPhase]);
 
   // 进入/离开聚焦 + 目标切换时的再聚焦
   useEffect(() => {
@@ -93,7 +96,7 @@ export default function CameraFocus({
     }
 
     wasActive.current = active;
-  }, [active, target, camera, controlsRef]);
+  }, [active, target, camera, controlsRef, setPhase]);
 
   useFrame((_, dt) => {
     const controls = controlsRef.current;

--- a/components/starfield/star.tsx
+++ b/components/starfield/star.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+/* eslint-disable react/no-unknown-property */
+
 import { Html, Billboard } from '@react-three/drei';
 import { useFrame } from '@react-three/fiber';
 import { useMemo, useRef, useState } from 'react';
@@ -16,6 +18,11 @@ export type StarProps = {
   distanceScale: number;
   glowTexture: THREE.Texture;
 };
+
+function seededUnit(seed: number, salt: number) {
+  const x = Math.sin(seed * 12.9898 + salt * 78.233) * 43758.5453;
+  return x - Math.floor(x);
+}
 
 export function Star({
   position,
@@ -34,10 +41,10 @@ export function Star({
   const [hovered, setHovered] = useState(false);
 
   // 每颗星的随机参数
-  const phase = useMemo(() => Math.random() * Math.PI * 2, []);
-  const twinkleSpeed = useMemo(() => 0.6 + Math.random() * 0.7, []);
-  const baseScale = useMemo(() => 0.4 + Math.random() * 0.4, []);
-  const hueJitter = useMemo(() => (Math.random() - 0.5) * 0.1, []);
+  const phase = useMemo(() => seededUnit(index, 1) * Math.PI * 2, [index]);
+  const twinkleSpeed = useMemo(() => 0.6 + seededUnit(index, 2) * 0.7, [index]);
+  const baseScale = useMemo(() => 0.4 + seededUnit(index, 3) * 0.4, [index]);
+  const hueJitter = useMemo(() => (seededUnit(index, 4) - 0.5) * 0.1, [index]);
   const baseColor = useMemo(() => new THREE.Color(color), [color]);
 
   // 颜色：轻微偏白提亮，避免“灰”
@@ -51,19 +58,32 @@ export function Star({
   );
 
   // 材质（加法混合，关深度测试让边缘更柔）
-  const mkMat = (opacity: number) =>
-    new THREE.MeshBasicMaterial({
-      map: glowTexture,
-      transparent: true,
-      opacity,
-      blending: THREE.AdditiveBlending,
-      depthWrite: false,
-      depthTest: false,
-      color: brightColor,
-    });
-
-  const innerMat = useMemo(() => mkMat(0.42), [glowTexture, brightColor]);
-  const outerMat = useMemo(() => mkMat(0.16), [glowTexture, brightColor]);
+  const innerMat = useMemo(
+    () =>
+      new THREE.MeshBasicMaterial({
+        map: glowTexture,
+        transparent: true,
+        opacity: 0.42,
+        blending: THREE.AdditiveBlending,
+        depthWrite: false,
+        depthTest: false,
+        color: brightColor,
+      }),
+    [glowTexture, brightColor],
+  );
+  const outerMat = useMemo(
+    () =>
+      new THREE.MeshBasicMaterial({
+        map: glowTexture,
+        transparent: true,
+        opacity: 0.16,
+        blending: THREE.AdditiveBlending,
+        depthWrite: false,
+        depthTest: false,
+        color: brightColor,
+      }),
+    [glowTexture, brightColor],
+  );
 
   useFrame(({ clock }) => {
     const t = clock.getElapsedTime();
@@ -107,7 +127,6 @@ export function Star({
           onPointerOut={() => setHovered(false)}
         >
           <planeGeometry args={[1, 1]} />
-          {/* @ts-ignore */}
           <primitive object={outerMat} attach="material" />
         </mesh>
       </Billboard>
@@ -120,7 +139,6 @@ export function Star({
           onPointerOut={() => setHovered(false)}
         >
           <planeGeometry args={[1, 1]} />
-          {/* @ts-ignore */}
           <primitive object={innerMat} attach="material" />
         </mesh>
       </Billboard>

--- a/components/starfield/starfield.tsx
+++ b/components/starfield/starfield.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+/* eslint-disable react/no-unknown-property */
+
 import { OrbitControls, Stars, Sparkles, Html } from '@react-three/drei';
 import { Canvas } from '@react-three/fiber';
 import { EffectComposer, Bloom, Vignette, Noise } from '@react-three/postprocessing';
@@ -14,8 +16,6 @@ import { presetStars } from '@/constants/star-presets';
 import { useRadialGlowTexture } from '@/hooks/use-radial-glow-texture';
 import {
   computeSafeRadius,
-  getRandomPosition,
-  randOnDisk,
   samplePositionsOnDisk,
 } from '@/lib/helpers';
 
@@ -23,10 +23,12 @@ import CameraFocus, { CameraPhase } from './camera-focus'; // ★ 引入独立�
 import { RotatingGroup } from './rotating-group';
 import { Star } from './star';
 
+import type { OrbitControls as OrbitControlsImpl } from 'three-stdlib';
+
 export default function StarField() {
   const router = useRouter();
   const glowTexture = useRadialGlowTexture();
-  const controlsRef = useRef<any>(null);
+  const controlsRef = useRef<OrbitControlsImpl>(null);
 
   const [aspect, setAspect] = useState(16 / 9);
   useEffect(() => {

--- a/next.config.ts
+++ b/next.config.ts
@@ -14,12 +14,6 @@ const nextConfig = {
   experimental: {
     optimizePackageImports: ['@mantine/core', '@mantine/hooks'],
   },
-  typescript: {
-    ignoreBuildErrors: true,
-  },
-  eslint: {
-    ignoreDuringBuilds: true,
-  },
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary

Restores the Next.js production build's TypeScript and ESLint validation by removing the build-skip settings from `next.config.ts`.

## What changed

- Removed `typescript.ignoreBuildErrors` and `eslint.ignoreDuringBuilds` from the Next config.
- Fixed the starfield build blockers caused by stale imports and untyped `OrbitControls` refs.
- Replaced render-time `Math.random()` calls in the star component with deterministic seeded values, satisfying React's purity lint while keeping per-star visual variation.
- Scoped the R3F JSX lint exception to starfield components where Three renderer props are expected.

## Validation

- `yarn build` passes with TypeScript and ESLint validation enabled.

## Notes

The build still reports existing non-blocking ESLint warnings in unrelated files, mostly import ordering and unused variables. Those can be cleaned up separately.