### PR TITLE
[codex] Refine starfield focus interactions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 # misc
 .DS_Store
 *.pem
+/tmp/
 
 # debug
 npm-debug.log*

--- a/components/starfield/camera-focus.tsx
+++ b/components/starfield/camera-focus.tsx
@@ -33,10 +33,11 @@ export default function CameraFocus({
 
   const prevCam = useRef(new THREE.Vector3());
   const prevTarget = useRef(new THREE.Vector3());
-
-  // 进入聚焦当下的方向与距离（保证拖拽后再点也能居中）
-  const focusDir = useRef(new THREE.Vector3());
-  const focusDist = useRef(0);
+  const startCam = useRef(new THREE.Vector3());
+  const startTarget = useRef(new THREE.Vector3());
+  const endCam = useRef(new THREE.Vector3());
+  const endTarget = useRef(new THREE.Vector3());
+  const progress = useRef(1);
 
   const mode = useRef<CameraPhase>('idle');
   const wasActive = useRef(false);
@@ -67,10 +68,23 @@ export default function CameraFocus({
     const controls = controlsRef.current;
     if (!controls) return;
 
-    // 工具函数：基于“当前相机与当前 controls.target”刷新聚焦向量与距离
-    const refreshFocusVector = () => {
-      focusDir.current.copy(camera.position).sub(controls.target).normalize();
-      focusDist.current = camera.position.distanceTo(controls.target);
+    const beginMove = (nextTarget: THREE.Vector3, speed: CameraPhase) => {
+      const focusDir = new THREE.Vector3().copy(camera.position).sub(controls.target);
+      const focusDist = focusDir.length();
+      if (focusDist > 0.0001) {
+        focusDir.normalize();
+      } else {
+        focusDir.set(0, 0, 1);
+      }
+
+      startCam.current.copy(camera.position);
+      startTarget.current.copy(controls.target);
+      endTarget.current.copy(nextTarget);
+      const minDistance = controls.minDistance || 0;
+      const desiredDistance = Math.max(focusDist * zoomFactor, minDistance);
+      endCam.current.copy(nextTarget).add(focusDir.multiplyScalar(desiredDistance));
+      progress.current = 0;
+      setPhase(speed);
     };
 
     if (active && target) {
@@ -78,59 +92,53 @@ export default function CameraFocus({
       if (!wasActive.current) {
         prevCam.current.copy(camera.position);
         prevTarget.current.copy(controls.target);
-        refreshFocusVector();
         lastFocusTarget.current.copy(target);
-        setPhase('focusing');
+        beginMove(target, 'focusing');
       } else {
         // 2) 已在聚焦状态下点了另一颗星：检测目标是否变化，变化则重新聚焦
         if (!target.equals(lastFocusTarget.current)) {
           // 不覆盖 prevCam/prevTarget，确保最后关闭还能回到最初视角
-          refreshFocusVector();
           lastFocusTarget.current.copy(target);
-          setPhase('focusing');
+          beginMove(target, 'focusing');
         }
       }
     } else if (!active && wasActive.current) {
       // 离开聚焦 → 恢复
+      startCam.current.copy(camera.position);
+      startTarget.current.copy(controls.target);
+      endCam.current.copy(prevCam.current);
+      endTarget.current.copy(prevTarget.current);
+      progress.current = 0;
       setPhase('restoring');
     }
 
     wasActive.current = active;
-  }, [active, target, camera, controlsRef, setPhase]);
+  }, [active, target, camera, controlsRef, setPhase, zoomFactor]);
 
   useFrame((_, dt) => {
     const controls = controlsRef.current;
     if (!controls) return;
 
-    if ((mode.current === 'focusing' || (active && target)) && target) {
-      const desiredPos = new THREE.Vector3()
-        .copy(target)
-        .add(focusDir.current.clone().multiplyScalar(focusDist.current * zoomFactor));
-
-      const k = Math.min(1, dt * (mode.current === 'focusing' ? inDamp : inDamp * 1.4));
-      camera.position.lerp(desiredPos, k);
-      controls.target.lerp(target, k);
+    if (mode.current === 'focusing') {
+      progress.current = Math.min(1, progress.current + dt * inDamp);
+      const t = 1 - Math.pow(1 - progress.current, 4);
+      camera.position.lerpVectors(startCam.current, endCam.current, t);
+      controls.target.lerpVectors(startTarget.current, endTarget.current, t);
       camera.lookAt(controls.target);
 
-      if (
-        mode.current === 'focusing' &&
-        camera.position.distanceTo(desiredPos) < 0.01 &&
-        controls.target.distanceTo(target) < 0.005
-      ) {
+      if (progress.current >= 1) {
         setPhase('idle');
       }
     }
 
     if (mode.current === 'restoring') {
-      const k = Math.min(1, dt * outDamp);
-      camera.position.lerp(prevCam.current, k);
-      controls.target.lerp(prevTarget.current, k);
+      progress.current = Math.min(1, progress.current + dt * outDamp);
+      const t = 1 - Math.pow(1 - progress.current, 4);
+      camera.position.lerpVectors(startCam.current, endCam.current, t);
+      controls.target.lerpVectors(startTarget.current, endTarget.current, t);
       camera.lookAt(controls.target);
 
-      if (
-        camera.position.distanceTo(prevCam.current) < 0.01 &&
-        controls.target.distanceTo(prevTarget.current) < 0.005
-      ) {
+      if (progress.current >= 1) {
         setPhase('idle');
       }
     }

--- a/components/starfield/star.tsx
+++ b/components/starfield/star.tsx
@@ -12,7 +12,7 @@ import type { MutableRefObject } from 'react';
 export type StarProps = {
   position: THREE.Vector3;
   index: number;
-  onClick: (index: number) => void;
+  onClick: (index: number, worldPosition: THREE.Vector3) => void;
   color: string;
   emissive: string; // 保留兼容
   name: string;
@@ -41,8 +41,7 @@ export function Star({
   densityScale = 1,
   worldPositionRef,
 }: StarProps) {
-  const [auraTexture, coreTexture, glintTexture] = useTexture([
-    '/star-assets/active/aura-kenney-circle-05.png',
+  const [coreTexture, glintTexture] = useTexture([
     '/star-assets/active/core-circle-05.png',
     '/star-assets/active/glint-star-04.png',
   ]);
@@ -51,18 +50,17 @@ export function Star({
   const innerRef = useRef<THREE.Mesh>(null); // 亮内核
   const coreRef = useRef<THREE.Mesh>(null); // 星点核心
   const glintRef = useRef<THREE.Mesh>(null); // 锐光星芒
-  const outerRef = useRef<THREE.Mesh>(null); // 外光晕
   const hoverMix = useRef(0);
   const [hovered, setHovered] = useState(false);
 
   useEffect(() => {
-    [auraTexture, coreTexture, glintTexture].forEach((texture) => {
+    [coreTexture, glintTexture].forEach((texture) => {
       texture.colorSpace = THREE.SRGBColorSpace;
       texture.wrapS = THREE.ClampToEdgeWrapping;
       texture.wrapT = THREE.ClampToEdgeWrapping;
       texture.needsUpdate = true;
     });
-  }, [auraTexture, coreTexture, glintTexture]);
+  }, [coreTexture, glintTexture]);
 
   // 每颗星的随机参数
   const phase = useMemo(() => seededUnit(index, 1) * Math.PI * 2, [index]);
@@ -84,19 +82,6 @@ export function Star({
     [baseColor, hueJitter],
   );
 
-  const outerMat = useMemo(
-    () =>
-      new THREE.MeshBasicMaterial({
-        map: auraTexture,
-        color: brightColor.clone().lerp(new THREE.Color('#dff8ff'), 0.42),
-        transparent: true,
-        opacity: 0.18,
-        blending: THREE.AdditiveBlending,
-        depthWrite: false,
-        depthTest: false,
-      }),
-    [auraTexture, brightColor],
-  );
   const innerMat = useMemo(
     () =>
       new THREE.MeshBasicMaterial({
@@ -224,15 +209,6 @@ export function Star({
       coreMaterial.uniforms.uTime.value = t;
       coreMaterial.uniforms.uHover.value = hoverMix.current;
     }
-    if (outerRef.current) {
-      const s = outerRef.current.scale.x || 1;
-      const target = scale * 1.68 * (0.98 + 0.02 * Math.sin(t * 0.23 + phase));
-      const next = THREE.MathUtils.damp(s, target, 5, dt);
-      outerRef.current.scale.set(next * 1.08, next, next);
-      outerRef.current.rotation.z = t * 0.035 + phase;
-      const outerMaterial = outerRef.current.material as THREE.MeshBasicMaterial;
-      outerMaterial.opacity = 0.07 * distanceScale * (0.88 + 0.12 * pulse);
-    }
     if (glintRef.current) {
       const target = scale * 0.72 * (0.96 + hoverMix.current * 0.18);
       glintRef.current.scale.set(target, target, target);
@@ -260,20 +236,20 @@ export function Star({
       <Billboard>
         <mesh
           ref={hitRef}
-          onClick={() => onClick(index)}
+          onClick={() => {
+            const focusPosition = new THREE.Vector3();
+            if (groupRef.current) {
+              groupRef.current.getWorldPosition(focusPosition);
+            } else {
+              focusPosition.copy(position);
+            }
+            onClick(index, focusPosition);
+          }}
           onPointerOver={() => setHovered(true)}
           onPointerOut={() => setHovered(false)}
         >
           <planeGeometry args={[1, 1]} />
           <primitive object={hitMat} attach="material" />
-        </mesh>
-      </Billboard>
-
-      {/* 贴图光球：素材负责柔边，交互由透明热区单独负责。 */}
-      <Billboard>
-        <mesh ref={outerRef}>
-          <planeGeometry args={[1, 1]} />
-          <primitive object={outerMat} attach="material" />
         </mesh>
       </Billboard>
 

--- a/components/starfield/starfield.tsx
+++ b/components/starfield/starfield.tsx
@@ -78,6 +78,7 @@ export default function StarField() {
   // 选中 & 面板
   const [open, setOpen] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+  const [focusTarget, setFocusTarget] = useState<THREE.Vector3 | null>(null);
   const selectedStar = selectedIndex !== null ? stars[selectedIndex] : null;
 
   // 相机阶段由 CameraFocus 回调驱动
@@ -98,27 +99,31 @@ export default function StarField() {
       if (e.key === 'Escape') {
         setOpen(false);
         setSelectedIndex(null);
+        setFocusTarget(null);
       }
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
   }, [open]);
 
-  const handleStarClick = (index: number) => {
+  const handleStarClick = (index: number, worldPosition: THREE.Vector3) => {
     setSelectedIndex(index);
+    setFocusTarget(worldPosition.clone());
     setOpen(true);
   };
 
   const handleClose = () => {
     setOpen(false); // 进入 restoring，回到原视角
     setSelectedIndex(null);
+    setFocusTarget(null);
   };
 
   return (
     <>
       {/* 3D 背景层 */}
-      <div className="fixed inset-0 z-0">
+      <div className="fixed inset-0 z-0 bg-[#02040a]">
         <Canvas
+          className="absolute inset-0"
           gl={{ alpha: false }}
           camera={{ position: [0, 0, 9.5], fov: 50 }}
           onPointerMissed={() => {
@@ -143,7 +148,7 @@ export default function StarField() {
 
           <CameraFocus
             controlsRef={controlsRef}
-            target={selectedIndex !== null ? starWorldPositionRefs[selectedIndex].current : null}
+            target={focusTarget}
             active={open}
             zoomFactor={0.13}
             inDamp={5.4}
@@ -255,14 +260,6 @@ export default function StarField() {
 
       {/* 前景 UI 层（不挡拖拽；真正可点元素单独开 pointer-events） */}
       <div className="pointer-events-none fixed inset-0 z-10">
-        <div
-          className="absolute inset-0"
-          style={{
-            background:
-              'linear-gradient(110deg, rgba(2,4,10,0.5) 0%, rgba(2,4,10,0.22) 22%, transparent 48%, rgba(2,4,10,0.18))',
-          }}
-        />
-
         <section className="absolute left-6 top-6 max-w-[min(26rem,calc(100vw-3rem))] text-white sm:left-10 sm:top-9">
           <div className="mb-4 h-px w-20 bg-gradient-to-r from-white/55 to-transparent" />
           <p


### PR DESCRIPTION
## Summary

- Removed the large outer aura layer and full-screen foreground gradient so the starfield feels cleaner.
- Reworked star focus to use a click-time world-position snapshot and a single interpolated camera path.
- Clamped focus distance to OrbitControls' minimum distance to prevent the selected star from briefly appearing oversized.
- Included the existing `/tmp/` gitignore update.

## Validation

- `yarn lint`
- `yarn tsc --noEmit`