### PR TITLE
Refine audio controls

### DIFF
--- a/components/starfield/audio-index.tsx
+++ b/components/starfield/audio-index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Pause, Play, Volume2, VolumeX } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
 import { cn } from '@/lib/utils';
 
@@ -42,6 +42,7 @@ const DEFAULT_MASTER_VOLUME = 0.22;
 const MAX_MASTER_VOLUME = 0.6;
 const FADE_OUT_MS = 680;
 const FADE_IN_MS = 1100;
+const PROGRESS_UPDATE_MS = 250;
 
 const TRACKS: Track[] = [
   {
@@ -138,19 +139,42 @@ function ramp(gain: AudioParam, start: number, peak: number, end: number, value:
   gain.exponentialRampToValueAtTime(0.0001, end);
 }
 
+function getTrackDuration(track: Track) {
+  if (track.kind === 'file') return 0;
+  return track.stepSeconds * track.chords.length * 2;
+}
+
+function formatTime(seconds: number, fallback = '0:00') {
+  if (!Number.isFinite(seconds) || seconds < 0) return fallback;
+
+  const rounded = Math.floor(seconds);
+  const minutes = Math.floor(rounded / 60);
+  const remainingSeconds = rounded % 60;
+  return `${minutes}:${String(remainingSeconds).padStart(2, '0')}`;
+}
+
 export default function AudioIndex({ isArchive }: { isArchive: boolean }) {
   const [isOpen, setIsOpen] = useState(false);
+  const [isTrackListOpen, setIsTrackListOpen] = useState(false);
   const [isPlaying, setIsPlaying] = useState(true);
   const [isMuted, setIsMuted] = useState(true);
   const [activeIndex, setActiveIndex] = useState(0);
   const [masterVolume, setMasterVolume] = useState(DEFAULT_MASTER_VOLUME);
+  const [panelHeight, setPanelHeight] = useState(56);
+  const [progressSeconds, setProgressSeconds] = useState(0);
+  const [durationSeconds, setDurationSeconds] = useState(0);
 
   const audioRef = useRef<HTMLAudioElement | null>(null);
+  const panelSummaryRef = useRef<HTMLDivElement | null>(null);
+  const panelDetailsRef = useRef<HTMLDivElement | null>(null);
   const contextRef = useRef<AudioContext | null>(null);
   const masterGainRef = useRef<GainNode | null>(null);
   const schedulerRef = useRef<number | null>(null);
   const transitionTimeoutRef = useRef<number | null>(null);
   const fileFadeFrameRef = useRef<number | null>(null);
+  const progressTimerRef = useRef<number | null>(null);
+  const proceduralStartedAtRef = useRef(0);
+  const pausedProgressRef = useRef(0);
   const nextStepTimeRef = useRef(0);
   const stepRef = useRef(0);
   const trackIndexRef = useRef(0);
@@ -164,6 +188,43 @@ export default function AudioIndex({ isArchive }: { isArchive: boolean }) {
 
   const currentTrack = TRACKS[activeIndex];
   const masterPercent = Math.round(masterVolume * 100);
+  const progressRatio = durationSeconds > 0
+    ? Math.min(1, Math.max(0, progressSeconds / durationSeconds))
+    : 0;
+
+  useLayoutEffect(() => {
+    let frameId: number;
+    const updatePanelHeight = (height: number) => {
+      frameId = window.requestAnimationFrame(() => setPanelHeight(height));
+    };
+
+    if (!isOpen) {
+      updatePanelHeight(56);
+      return () => window.cancelAnimationFrame(frameId);
+    }
+
+    const summary = panelSummaryRef.current;
+    if (!summary) return;
+
+    const updateHeight = () => {
+      const details = panelDetailsRef.current;
+      const detailsHeight = isTrackListOpen && details ? details.scrollHeight : 0;
+      updatePanelHeight(summary.scrollHeight + detailsHeight + 24);
+    };
+
+    updateHeight();
+
+    const observer = new ResizeObserver(updateHeight);
+    observer.observe(summary);
+    if (panelDetailsRef.current) {
+      observer.observe(panelDetailsRef.current);
+    }
+
+    return () => {
+      window.cancelAnimationFrame(frameId);
+      observer.disconnect();
+    };
+  }, [isOpen, isTrackListOpen]);
 
   const getEffectiveVolume = useCallback((track: Track, muted = isMuted) => {
     if (muted) return 0;
@@ -183,6 +244,38 @@ export default function AudioIndex({ isArchive }: { isArchive: boolean }) {
       transitionTimeoutRef.current = null;
     }
   }, []);
+
+  const clearProgressTimer = useCallback(() => {
+    if (progressTimerRef.current !== null) {
+      window.clearInterval(progressTimerRef.current);
+      progressTimerRef.current = null;
+    }
+  }, []);
+
+  const startProceduralProgress = useCallback((
+    track: ProceduralTrack,
+    context: AudioContext,
+    elapsedSeconds = 0,
+  ) => {
+    clearProgressTimer();
+
+    const duration = getTrackDuration(track);
+    proceduralStartedAtRef.current = context.currentTime - elapsedSeconds;
+    setProgressSeconds(Math.min(duration, Math.max(0, elapsedSeconds)));
+    setDurationSeconds(duration);
+
+    progressTimerRef.current = window.setInterval(() => {
+      const activeTrack = TRACKS[trackIndexRef.current];
+      const audioContext = contextRef.current;
+      if (!audioContext || activeTrack.kind !== 'procedural') return;
+
+      const activeDuration = getTrackDuration(activeTrack);
+      const elapsed = audioContext.currentTime - proceduralStartedAtRef.current;
+      setProgressSeconds(Math.min(activeDuration, Math.max(0, elapsed)));
+      setDurationSeconds(activeDuration);
+    }, PROGRESS_UPDATE_MS);
+
+  }, [clearProgressTimer]);
 
   const trimNodes = useCallback((time: number) => {
     nodesRef.current = nodesRef.current.filter((record) => {
@@ -327,6 +420,39 @@ export default function AudioIndex({ isArchive }: { isArchive: boolean }) {
     }
   }, [scheduleBell, scheduleDust, schedulePad]);
 
+  const startProceduralScheduler = useCallback((
+    track: ProceduralTrack,
+    context: AudioContext,
+    elapsedSeconds = 0,
+  ) => {
+    const duration = getTrackDuration(track);
+    const normalizedElapsed = duration > 0 ? elapsedSeconds % duration : 0;
+    const step = Math.floor(normalizedElapsed / track.stepSeconds);
+    const stepOffset = normalizedElapsed - step * track.stepSeconds;
+    const isAtStepStart = stepOffset < 0.001;
+
+    stepRef.current = isAtStepStart ? step : step + 1;
+    proceduralStartedAtRef.current = context.currentTime - normalizedElapsed;
+    nextStepTimeRef.current = context.currentTime + (
+      isAtStepStart ? 0.08 : Math.max(0.08, track.stepSeconds - stepOffset)
+    );
+
+    schedulerRef.current = window.setInterval(() => {
+      const audioContext = contextRef.current;
+      if (!audioContext) return;
+
+      while (nextStepTimeRef.current < audioContext.currentTime + 0.42) {
+        const activeTrack = TRACKS[trackIndexRef.current];
+        if (activeTrack.kind !== 'procedural') return;
+
+        scheduleStep(nextStepTimeRef.current);
+        nextStepTimeRef.current += activeTrack.stepSeconds;
+      }
+
+      trimNodes(audioContext.currentTime);
+    }, 120);
+  }, [scheduleStep, trimNodes]);
+
   const fadeFileVolume = useCallback((targetVolume: number, durationMs: number) => {
     const audio = audioRef.current;
     if (!audio) return;
@@ -423,12 +549,16 @@ export default function AudioIndex({ isArchive }: { isArchive: boolean }) {
 
     const beginTrack = () => {
       clearScheduler();
+      clearProgressTimer();
       stopNodes();
       stopFile();
       trackIndexRef.current = index;
       stepRef.current = 0;
+      pausedProgressRef.current = 0;
       setActiveIndex(index);
       setIsPlaying(true);
+      setProgressSeconds(0);
+      setDurationSeconds(getTrackDuration(track));
 
       if (track.kind === 'file') {
         playFile(track, true);
@@ -442,23 +572,9 @@ export default function AudioIndex({ isArchive }: { isArchive: boolean }) {
       }
 
       fadeProceduralVolume(0, 0);
-      nextStepTimeRef.current = context.currentTime + 0.08;
       fadeProceduralVolume(getEffectiveVolume(track), FADE_IN_MS);
-
-      schedulerRef.current = window.setInterval(() => {
-        const audioContext = contextRef.current;
-        if (!audioContext) return;
-
-        while (nextStepTimeRef.current < audioContext.currentTime + 0.42) {
-          const track = TRACKS[trackIndexRef.current];
-          if (track.kind !== 'procedural') return;
-
-          scheduleStep(nextStepTimeRef.current);
-          nextStepTimeRef.current += track.stepSeconds;
-        }
-
-        trimNodes(audioContext.currentTime);
-      }, 120);
+      startProceduralProgress(track, context, 0);
+      startProceduralScheduler(track, context, 0);
     };
 
     if (shouldFadeOut) {
@@ -471,6 +587,7 @@ export default function AudioIndex({ isArchive }: { isArchive: boolean }) {
     beginTrack();
   }, [
     clearScheduler,
+    clearProgressTimer,
     clearTransition,
     ensureContext,
     fadeCurrentOutput,
@@ -478,10 +595,10 @@ export default function AudioIndex({ isArchive }: { isArchive: boolean }) {
     getEffectiveVolume,
     isPlaying,
     playFile,
-    scheduleStep,
+    startProceduralProgress,
+    startProceduralScheduler,
     stopFile,
     stopNodes,
-    trimNodes,
   ]);
 
   useEffect(() => {
@@ -516,13 +633,87 @@ export default function AudioIndex({ isArchive }: { isArchive: boolean }) {
   const pause = useCallback(() => {
     clearTransition();
     clearScheduler();
+    clearProgressTimer();
+    const track = TRACKS[trackIndexRef.current];
+    const audio = audioRef.current;
+
+    if (track.kind === 'file' && audio) {
+      pausedProgressRef.current = audio.currentTime;
+      audio.pause();
+      setProgressSeconds(audio.currentTime);
+      setIsPlaying(false);
+      return;
+    }
+
+    const context = contextRef.current;
+    if (track.kind === 'procedural' && context) {
+      const duration = getTrackDuration(track);
+      const elapsed = Math.max(0, context.currentTime - proceduralStartedAtRef.current);
+      pausedProgressRef.current = duration > 0 ? elapsed % duration : elapsed;
+      setProgressSeconds(pausedProgressRef.current);
+    }
+
     fadeCurrentOutput(0, FADE_OUT_MS);
     transitionTimeoutRef.current = window.setTimeout(() => {
       stopNodes();
-      stopFile();
     }, FADE_OUT_MS);
     setIsPlaying(false);
-  }, [clearScheduler, clearTransition, fadeCurrentOutput, stopFile, stopNodes]);
+  }, [clearScheduler, clearProgressTimer, clearTransition, fadeCurrentOutput, stopNodes]);
+
+  const resume = useCallback(() => {
+    clearTransition();
+    const track = TRACKS[trackIndexRef.current];
+
+    setIsPlaying(true);
+
+    if (track.kind === 'file') {
+      const audio = audioRef.current;
+      if (!audio) {
+        startFrom(activeIndex, { fadeOut: false });
+        return;
+      }
+
+      audio.muted = isMuted;
+      audio.currentTime = pausedProgressRef.current || audio.currentTime;
+      void audio.play().catch(() => undefined);
+      fadeFileVolume(getEffectiveVolume(track), FADE_IN_MS);
+      return;
+    }
+
+    const context = ensureContext();
+    if (context.state === 'suspended') {
+      void context.resume().catch(() => undefined);
+    }
+
+    clearScheduler();
+    stopNodes();
+    fadeProceduralVolume(0, 0);
+    fadeProceduralVolume(getEffectiveVolume(track), FADE_IN_MS);
+    startProceduralScheduler(track, context, pausedProgressRef.current);
+    startProceduralProgress(track, context, pausedProgressRef.current);
+  }, [
+    activeIndex,
+    clearScheduler,
+    clearTransition,
+    ensureContext,
+    fadeFileVolume,
+    fadeProceduralVolume,
+    getEffectiveVolume,
+    isMuted,
+    startFrom,
+    startProceduralProgress,
+    startProceduralScheduler,
+    stopNodes,
+  ]);
+
+  const togglePlayback = useCallback(() => {
+    if (isPlaying) {
+      pause();
+      return;
+    }
+
+    resume();
+  }, [isPlaying, pause, resume]);
 
   useEffect(() => {
     const masterGain = masterGainRef.current;
@@ -558,10 +749,11 @@ export default function AudioIndex({ isArchive }: { isArchive: boolean }) {
   useEffect(() => () => {
     clearTransition();
     clearScheduler();
+    clearProgressTimer();
     stopNodes();
     stopFile();
     void contextRef.current?.close();
-  }, [clearScheduler, clearTransition, stopFile, stopNodes]);
+  }, [clearScheduler, clearProgressTimer, clearTransition, stopFile, stopNodes]);
 
   const palette = useMemo(() => {
     if (isArchive) {
@@ -586,43 +778,96 @@ export default function AudioIndex({ isArchive }: { isArchive: boolean }) {
   }, [isArchive]);
 
   return (
-    <div className="pointer-events-auto absolute bottom-5 left-5 z-20 sm:bottom-7 sm:left-7">
+    <div
+      className={cn(
+        'pointer-events-auto absolute right-2 top-2 z-20 transition-[width,height] duration-[420ms] ease-[cubic-bezier(0.4,0,0.2,1)] motion-reduce:transition-none sm:right-4 sm:top-4',
+        isOpen ? 'w-[min(18rem,calc(100vw-2.5rem))]' : 'w-14',
+      )}
+      style={{ height: panelHeight }}
+      onMouseEnter={() => setIsOpen(true)}
+      onMouseLeave={() => setIsOpen(false)}
+      onFocus={() => setIsOpen(true)}
+    >
+      {/* Instrumental background music has no spoken content to caption. */}
+      {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
+      <audio
+        ref={audioRef}
+        aria-hidden="true"
+        preload="auto"
+        onLoadedMetadata={(event) => {
+          const duration = event.currentTarget.duration;
+          if (Number.isFinite(duration)) {
+            setDurationSeconds(duration);
+          }
+        }}
+        onTimeUpdate={(event) => {
+          const activeTrack = TRACKS[trackIndexRef.current];
+          if (activeTrack.kind !== 'file') return;
+
+          setProgressSeconds(event.currentTarget.currentTime);
+          if (Number.isFinite(event.currentTarget.duration)) {
+            setDurationSeconds(event.currentTarget.duration);
+          }
+        }}
+        onEnded={() => startFrom((activeIndex + 1) % TRACKS.length, { fadeOut: false })}
+      />
+
       <div
         className={cn(
-          'w-[min(18rem,calc(100vw-2.5rem))] border px-3 py-2 shadow-[0_18px_52px_rgba(0,0,0,0.22)] backdrop-blur-md transition-[border-color,background-color,opacity] duration-200 ease-[var(--ease-out-quint)]',
+          'absolute right-0 top-0 size-full overflow-hidden border shadow-[0_18px_52px_rgba(0,0,0,0.22)] backdrop-blur-md transition-[border-color,background-color,box-shadow] duration-[420ms] ease-[cubic-bezier(0.4,0,0.2,1)]',
           palette.panel,
+          !isOpen && 'border-transparent bg-transparent shadow-none backdrop-blur-none',
         )}
+        aria-hidden={!isOpen}
+      />
+
+      <button
+        type="button"
+        onClick={toggleMute}
+        className={cn(
+          'absolute right-3 top-3 z-20 grid size-7 place-items-center border transition-[border-color,background-color,color] duration-[260ms] ease-[cubic-bezier(0.4,0,0.2,1)]',
+          isArchive
+            ? 'border-[rgba(36,48,64,0.16)] bg-transparent text-[#66727f] hover:border-[rgba(36,48,64,0.3)] hover:text-[#172033]'
+            : 'border-white/12 bg-transparent text-white/55 hover:border-white/24 hover:text-white/90',
+        )}
+        aria-expanded={isOpen}
+        aria-label={isMuted ? 'Unmute audio index' : 'Mute audio index'}
       >
-        {/* Instrumental background music has no spoken content to caption. */}
-        {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
-        <audio
-          ref={audioRef}
-          aria-hidden="true"
-          preload="auto"
-          onEnded={() => startFrom((activeIndex + 1) % TRACKS.length, { fadeOut: false })}
-        />
+        {isMuted ? <VolumeX className="size-3.5" /> : <Volume2 className="size-3.5" />}
+      </button>
 
-        <div className="flex items-center justify-between gap-3">
-          <button
-            type="button"
-            onClick={() => setIsOpen((value) => !value)}
-            className={cn(
-              'min-w-0 text-left text-[10px] font-semibold uppercase transition-colors',
-              palette.muted,
-              palette.hover,
-            )}
-            style={{ letterSpacing: '0.18em' }}
-            aria-expanded={isOpen}
-          >
-            audio index
-          </button>
-
-          <div className="flex shrink-0 items-center gap-1">
+      <div
+        className={cn(
+          'absolute inset-0 overflow-hidden px-3 py-3 transition-[opacity] duration-200 ease-[cubic-bezier(0.4,0,0.2,1)]',
+          isOpen
+            ? 'opacity-100 delay-150'
+            : 'pointer-events-none opacity-0 delay-0',
+        )}
+        aria-hidden={!isOpen}
+      >
+        <div ref={panelSummaryRef}>
+          <div className="mb-3 flex min-h-7 items-center justify-between gap-3 pr-16">
             <button
               type="button"
-              onClick={() => (isPlaying ? pause() : startFrom(activeIndex))}
+              onClick={() => setIsOpen((value) => !value)}
+              tabIndex={isOpen ? 0 : -1}
               className={cn(
-                'grid size-7 place-items-center border transition-colors',
+                'min-w-0 text-left text-[10px] font-semibold uppercase transition-colors',
+                palette.muted,
+                palette.hover,
+              )}
+              style={{ letterSpacing: '0.18em' }}
+              aria-expanded={isOpen}
+            >
+              audio index
+            </button>
+
+            <button
+              type="button"
+              onClick={togglePlayback}
+              tabIndex={isOpen ? 0 : -1}
+              className={cn(
+                'absolute right-12 top-3 grid size-7 shrink-0 place-items-center border transition-colors',
                 isArchive
                   ? 'border-[rgba(36,48,64,0.16)] text-[#66727f] hover:border-[rgba(36,48,64,0.3)] hover:text-[#172033]'
                   : 'border-white/12 text-white/55 hover:border-white/24 hover:text-white/90',
@@ -631,53 +876,61 @@ export default function AudioIndex({ isArchive }: { isArchive: boolean }) {
             >
               {isPlaying ? <Pause className="size-3.5" /> : <Play className="size-3.5" />}
             </button>
-            <button
-              type="button"
-              onClick={toggleMute}
-              className={cn(
-                'grid size-7 place-items-center border transition-colors',
-                isArchive
-                  ? 'border-[rgba(36,48,64,0.16)] text-[#66727f] hover:border-[rgba(36,48,64,0.3)] hover:text-[#172033]'
-                  : 'border-white/12 text-white/55 hover:border-white/24 hover:text-white/90',
-              )}
-              aria-label={isMuted ? 'Unmute audio index' : 'Mute audio index'}
+          </div>
+
+          <div className={cn('mb-2 h-px', palette.line)} />
+
+          <button
+            type="button"
+            onClick={() => setIsTrackListOpen((value) => !value)}
+            tabIndex={isOpen ? 0 : -1}
+            className="flex w-full items-center justify-between gap-3 text-left"
+          >
+            <span
+              className={cn('truncate text-xs uppercase', isArchive ? 'text-[#172033]' : 'text-white/86')}
+              style={{ letterSpacing: '0.12em' }}
             >
-              {isMuted ? <VolumeX className="size-3.5" /> : <Volume2 className="size-3.5" />}
-            </button>
+              {currentTrack.title}
+            </span>
+            <span
+              className={cn('shrink-0 text-[10px] uppercase', palette.faint)}
+              style={{ letterSpacing: '0.16em' }}
+            >
+              {isPlaying ? 'on air' : 'standby'}
+            </span>
+          </button>
+
+          <div className={cn('mt-2 flex items-center gap-3', isTrackListOpen && 'mb-2')}>
+            <div
+              className={cn(
+                'h-px flex-1 overflow-hidden',
+                isArchive ? 'bg-[rgba(36,48,64,0.16)]' : 'bg-white/12',
+              )}
+              aria-hidden="true"
+            >
+              <div
+                className={cn('h-full', isArchive ? 'bg-[#477c86]' : 'bg-[#aad7dc]')}
+                style={{ width: `${progressRatio * 100}%` }}
+              />
+            </div>
+            <div
+              className={cn('shrink-0 text-[9px] uppercase tabular-nums', palette.faint)}
+              style={{ letterSpacing: '0.12em' }}
+            >
+              {formatTime(progressSeconds)} / {formatTime(durationSeconds, '--:--')}
+            </div>
           </div>
         </div>
 
-        <div className={cn('mt-2 h-px', palette.line)} />
-
-        <button
-          type="button"
-          onClick={() => setIsOpen((value) => !value)}
-          className="mt-2 flex w-full items-center justify-between gap-3 text-left"
-        >
-          <span
-            className={cn('truncate text-xs uppercase', isArchive ? 'text-[#172033]' : 'text-white/86')}
-            style={{ letterSpacing: '0.12em' }}
-          >
-            {currentTrack.title}
-          </span>
-          <span
-            className={cn('shrink-0 text-[10px] uppercase', palette.faint)}
-            style={{ letterSpacing: '0.16em' }}
-          >
-            {isPlaying ? 'on air' : 'standby'}
-          </span>
-        </button>
-
         <div
           className={cn(
-            'grid overflow-hidden transition-[grid-template-rows,opacity,transform,margin-top] duration-300 ease-[var(--ease-out-quint)] motion-reduce:transition-none',
-            isOpen
-              ? 'mt-2 grid-rows-[1fr] translate-y-0 opacity-100'
-              : 'mt-0 grid-rows-[0fr] -translate-y-1 opacity-0',
+            'grid overflow-hidden transition-[grid-template-rows,transform,margin-top] duration-300 ease-[var(--ease-out-quint)] motion-reduce:transition-none',
+            isOpen && isTrackListOpen
+              ? 'mt-2 grid-rows-[1fr] translate-y-0'
+              : 'mt-0 grid-rows-[0fr] -translate-y-1',
           )}
-          aria-hidden={!isOpen}
         >
-          <div className="min-h-0 overflow-hidden">
+          <div className="min-h-0 overflow-hidden" ref={panelDetailsRef}>
             <div className="space-y-1">
               <div
                 className={cn(
@@ -685,9 +938,8 @@ export default function AudioIndex({ isArchive }: { isArchive: boolean }) {
                   isArchive
                     ? 'border-[rgba(36,48,64,0.1)] bg-[rgba(23,32,51,0.035)]'
                     : 'border-white/8 bg-white/[0.035]',
-                  isOpen ? 'translate-y-0 opacity-100' : '-translate-y-1 opacity-0',
+                  isOpen && isTrackListOpen ? 'translate-y-0' : '-translate-y-1',
                 )}
-                style={{ transitionDelay: isOpen ? '0ms' : '0ms' }}
               >
                 <div className="mb-1.5 flex items-center justify-between gap-3">
                   <label
@@ -711,7 +963,7 @@ export default function AudioIndex({ isArchive }: { isArchive: boolean }) {
                   max={MAX_MASTER_VOLUME}
                   step={0.01}
                   value={masterVolume}
-                  tabIndex={isOpen ? 0 : -1}
+                  tabIndex={isOpen && isTrackListOpen ? 0 : -1}
                   onChange={(event) => setMasterVolume(Number(event.target.value))}
                   className={cn(
                     'block h-4 w-full cursor-pointer appearance-none bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30',
@@ -731,16 +983,16 @@ export default function AudioIndex({ isArchive }: { isArchive: boolean }) {
                     key={track.id}
                     type="button"
                     onClick={() => startFrom(index)}
-                    tabIndex={isOpen ? 0 : -1}
+                    tabIndex={isOpen && isTrackListOpen ? 0 : -1}
                     className={cn(
                       'flex w-full items-center justify-between gap-3 border px-2 py-1.5 text-left transition-[border-color,background-color,color,opacity,transform] duration-300 ease-[var(--ease-out-quint)] motion-reduce:transition-none',
                       isArchive
                         ? 'border-[rgba(36,48,64,0.1)] text-[#66727f] hover:border-[rgba(36,48,64,0.24)] hover:text-[#172033]'
                         : 'border-white/8 text-white/52 hover:border-white/20 hover:text-white/88',
-                      isOpen ? 'translate-y-0 opacity-100' : '-translate-y-1 opacity-0',
+                      isOpen && isTrackListOpen ? 'translate-y-0' : '-translate-y-1',
                       isActive && palette.active,
                     )}
-                    style={{ transitionDelay: isOpen ? `${(index + 1) * 34}ms` : '0ms' }}
+                    style={{ transitionDelay: isOpen && isTrackListOpen ? `${(index + 1) * 34}ms` : '0ms' }}
                   >
                     <span className="min-w-0">
                       <span


### PR DESCRIPTION
## Summary
- Move the audio index into a compact top-right hover panel that collapses back into the mute button.
- Add a current-track progress line and elapsed / duration readout.
- Make the play button pause and resume from the current position instead of restarting playback.

## Validation
- `yarn lint`
- Manual browser check on `localhost:3000`: pause held the current timestamp and resume continued from that point without console errors.